### PR TITLE
Add Build & Deploy workflow with GitHub Actions

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,0 +1,42 @@
+name: Build & Deploy
+
+on: [pull_request, push]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: build-and-deploy
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Upload as artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: dist
+
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,7 +1,11 @@
 name: Build & Deploy
 
-on: [pull_request, push]
+on: 
+  push:
+    branches: 
+      - main
 
+# Grant GITHUB_TOKEN the permissions required to make a Pages deployment
 permissions:
   contents: read
   pages: write
@@ -26,7 +30,6 @@ jobs:
         uses: actions/upload-pages-artifact@v1
         with:
           path: dist
-
 
   deploy:
     needs: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,14 @@
+name: Build
+
+on: [pull_request, push]
+
+jobs:
+  main:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+
+      - run: npm ci
+      
+      - name: Build
+        run: npm run build

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ dist
 repository_test/repository/local-mp4
 
 .DS_Store
+
+/build

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,3 @@ dist
 repository_test/repository/local-mp4
 
 .DS_Store
-
-/build


### PR DESCRIPTION
This workflow `build-and-deploy.yml` will publish a test page, where the player is shown (on push to main-branch). The test page will be automatically redeployed, whenever there is a push to the main-branch (this can be changed).

This can be very useful for testing (especially as a reviewer). You simply open the test page and see/test/review the changes, instead of pulling the changes, building the project and then test it locally. In my opinion this is a great advantage.

The workflow can be customized and extended (my version is only a basic version).

If this will be merged, you have to configure your site to publish with GitHub Actions (only once):
- Go to **Settings** in your repository, left on the sidebar click **Pages** and choose **GitHub Actions** from **Source** Dropdown. 
- You can also specify a custom domain (if you have one, something like test.paella.upv.es) if you want to. I even recommend that, currently I have to add the ID each time (/?id=belmar-multiresolution-remote).

For more informations see: [Publishing with a custom GitHub Actions workflow](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site#publishing-with-a-custom-github-actions-workflow)