### PR TITLE
Add Fallback Identifier

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -1,4 +1,5 @@
 {
+    "fallbackId": "belmar-multiresolution-remote",
     "repositoryUrl": "repository",
     "manifestFileName": "data.json",
 


### PR DESCRIPTION
This patch adds a fallback identifier to the configuration so that you will get a video instead of an empty page by default when opening the development server or the GitHub Pages deployment.